### PR TITLE
Add core extension with dig for ruby < 2.3

### DIFF
--- a/lib/rosetta.rb
+++ b/lib/rosetta.rb
@@ -1,6 +1,8 @@
 require 'i18n'
 require 'request_store'
 
+require 'rosetta/core_ext/dig'
+
 require 'rosetta/config'
 require 'rosetta/engine'
 require 'rosetta/i18n_with_stored_phrases'

--- a/lib/rosetta/core_ext/dig.rb
+++ b/lib/rosetta/core_ext/dig.rb
@@ -1,0 +1,21 @@
+unless Hash.instance_methods.include?(:dig)
+  Hash.class_eval do
+    def dig(key, *args)
+      value = self[key]
+      return value if args.length == 0 || value.nil?
+
+      value.dig(*args)
+    end
+  end
+end
+
+unless Array.instance_methods.include?(:dig)
+  Array.class_eval do
+    def dig(key, *args)
+      value = self.at(key)
+      return value if args.length == 0 || value.nil?
+
+      value.dig(*args)
+    end
+  end
+end

--- a/lib/rosetta/core_ext/dig.rb
+++ b/lib/rosetta/core_ext/dig.rb
@@ -2,7 +2,7 @@ unless Hash.instance_methods.include?(:dig)
   Hash.class_eval do
     def dig(key, *args)
       value = self[key]
-      return value if args.length == 0 || value.nil?
+      return value if args.empty? || value.nil?
 
       value.dig(*args)
     end
@@ -12,8 +12,8 @@ end
 unless Array.instance_methods.include?(:dig)
   Array.class_eval do
     def dig(key, *args)
-      value = self.at(key)
-      return value if args.length == 0 || value.nil?
+      value = at(key)
+      return value if args.empty? || value.nil?
 
       value.dig(*args)
     end


### PR DESCRIPTION
Relates to #38 but we can't add support yet because the latest version of capybara does not support Ruby < 2.3 so we need to make more changes to be able to test this with ruby < 2.3, like add additional Gemfiles.